### PR TITLE
nimble/ll: Account for host provided Max_CE_length

### DIFF
--- a/nimble/controller/include/controller/ble_ll_conn.h
+++ b/nimble/controller/include/controller/ble_ll_conn.h
@@ -291,8 +291,7 @@ struct ble_ll_conn_sm
     /* Connection timing */
     uint16_t conn_itvl;
     uint16_t supervision_tmo;
-    uint16_t min_ce_len;
-    uint16_t max_ce_len;
+    uint32_t max_ce_len_ticks;
     uint16_t tx_win_off;
     uint32_t anchor_point;
     uint8_t anchor_point_usecs;     /* XXX: can this be uint8_t ?*/

--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -941,6 +941,12 @@ ble_ll_conn_get_next_sched_time(struct ble_ll_conn_sm *connsm)
 
     ce_end -= ble_ll_tmr_u2t_up(MYNEWT_VAL(BLE_LL_CONN_EVENT_END_MARGIN));
 
+    if (connsm->max_ce_len_ticks) {
+        if (LL_TMR_LT(connsm->anchor_point + connsm->max_ce_len_ticks, ce_end)) {
+            ce_end = connsm->anchor_point + connsm->max_ce_len_ticks;
+        }
+    }
+
     if (ble_ll_sched_next_time(&next_sched_time)) {
         if (LL_TMR_LT(next_sched_time, ce_end)) {
             ce_end = next_sched_time;
@@ -1801,8 +1807,7 @@ ble_ll_conn_central_init(struct ble_ll_conn_sm *connsm,
     connsm->conn_itvl_usecs = cc_params->conn_itvl_usecs;
     connsm->periph_latency = cc_params->conn_latency;
     connsm->supervision_tmo = cc_params->supervision_timeout;
-    connsm->min_ce_len = cc_params->min_ce_len;
-    connsm->max_ce_len = cc_params->max_ce_len;
+    connsm->max_ce_len_ticks = ble_ll_tmr_u2t_up(cc_params->max_ce_len * BLE_LL_CONN_CE_USECS);
 }
 #endif
 
@@ -2576,6 +2581,11 @@ ble_ll_conn_next_event(struct ble_ll_conn_sm *connsm)
 
         ble_ll_conn_itvl_to_ticks(connsm->conn_itvl, &connsm->conn_itvl_ticks,
                                   &connsm->conn_itvl_usecs);
+
+        if (connsm->conn_param_req.handle != 0) {
+            connsm->max_ce_len_ticks = ble_ll_tmr_u2t_up(connsm->conn_param_req.max_ce_len * BLE_LL_CONN_CE_USECS);
+            connsm->conn_param_req.handle = 0;
+        }
 
         if (upd->winoffset != 0) {
             usecs = upd->winoffset * BLE_LL_CONN_ITVL_USECS;

--- a/nimble/controller/src/ble_ll_conn_hci.c
+++ b/nimble/controller/src/ble_ll_conn_hci.c
@@ -480,12 +480,14 @@ ble_ll_conn_hci_create_check_params(struct ble_ll_conn_create_params *cc_params)
         return BLE_ERR_INV_HCI_CMD_PARMS;
     }
 
-    /* Adjust min/max ce length to be less than interval */
-    if (cc_params->min_ce_len > cc_params->conn_itvl) {
-        cc_params->min_ce_len = cc_params->conn_itvl;
+    /* Adjust min/max ce length to be less than interval
+     * Note that interval is in 1.25ms and CE is in 625us
+     */
+    if (cc_params->min_ce_len > cc_params->conn_itvl * 2) {
+        cc_params->min_ce_len = cc_params->conn_itvl * 2;
     }
-    if (cc_params->max_ce_len > cc_params->conn_itvl) {
-        cc_params->max_ce_len = cc_params->conn_itvl;
+    if (cc_params->max_ce_len > cc_params->conn_itvl * 2) {
+        cc_params->max_ce_len = cc_params->conn_itvl * 2;
     }
 
     /* Precalculate conn interval */


### PR DESCRIPTION
If host provides maximum CE length (when initiating connection or updating its parameters) LL will take it into account when checking if more packages can be send in current event.

Upstream commit: 357f7210ee0640c5c74d351dd51de9d4068a2664