### PR TITLE
nimble/ll: Allow to locally update connection min/max CE length

### DIFF
--- a/nimble/controller/include/controller/ble_ll_hci.h
+++ b/nimble/controller/include/controller/ble_ll_hci.h
@@ -42,7 +42,7 @@ extern const uint8_t g_ble_ll_supp_cmds[BLE_LL_SUPP_CMD_LEN];
  */
 #define BLE_LL_CFG_NUM_HCI_CMD_PKTS     (1)
 
-typedef void (*ble_ll_hci_post_cmd_complete_cb)(void);
+typedef void (*ble_ll_hci_post_cmd_complete_cb)(void *user_data);
 
 #if MYNEWT_VAL(BLE_LL_HCI_VS)
 typedef int (* ble_ll_hci_vs_cb_t)(uint16_t ocf,
@@ -82,6 +82,9 @@ bool ble_ll_hci_adv_mode_ext(void);
 
 /* Check if max octets/time are within allowed range */
 int ble_ll_hci_check_dle(uint16_t max_octets, uint16_t max_time);
+
+/* Used to set post HCI command hook */
+void ble_ll_hci_post_cmd_cb_set(ble_ll_hci_post_cmd_complete_cb cb, void *user_data);
 
 #if MYNEWT_VAL(BLE_LL_HCI_VS)
 void ble_ll_hci_vs_register(struct ble_ll_hci_vs_cmd *cmds, uint32_t num_cmds);

--- a/nimble/controller/include/controller/ble_ll_sync.h
+++ b/nimble/controller/include/controller/ble_ll_sync.h
@@ -34,7 +34,7 @@ struct ble_ll_scan_addr_data;
 struct ble_ll_sync_sm;
 
 int ble_ll_sync_create(const uint8_t *cmdbuf, uint8_t len);
-int ble_ll_sync_cancel(ble_ll_hci_post_cmd_complete_cb *post_cmd_cb);
+int ble_ll_sync_cancel(void);
 int ble_ll_sync_terminate(const uint8_t *cmdbuf, uint8_t len);
 int ble_ll_sync_list_add(const uint8_t *cmdbuf, uint8_t len);
 int ble_ll_sync_list_remove(const uint8_t *cmdbuf, uint8_t len);

--- a/nimble/controller/src/ble_ll_conn_priv.h
+++ b/nimble/controller/src/ble_ll_conn_priv.h
@@ -205,7 +205,7 @@ int ble_ll_conn_hci_param_rr(const uint8_t *cmdbuf, uint8_t len,
                              uint8_t *rspbuf, uint8_t *rsplen);
 int ble_ll_conn_hci_param_nrr(const uint8_t *cmdbuf, uint8_t len,
                              uint8_t *rspbuf, uint8_t *rsplen);
-int ble_ll_conn_create_cancel(ble_ll_hci_post_cmd_complete_cb *post_cmd_cb);
+int ble_ll_conn_create_cancel(void);
 void ble_ll_conn_num_comp_pkts_event_send(struct ble_ll_conn_sm *connsm);
 void ble_ll_conn_comp_event_send(struct ble_ll_conn_sm *connsm, uint8_t status,
                                  uint8_t *evbuf, struct ble_ll_adv_sm *advsm);

--- a/nimble/controller/src/ble_ll_hci.c
+++ b/nimble/controller/src/ble_ll_hci.c
@@ -54,6 +54,9 @@ static uint64_t g_ble_ll_hci_event_mask2;
 static int16_t rx_path_pwr_compensation;
 static int16_t tx_path_pwr_compensation;
 
+static ble_ll_hci_post_cmd_complete_cb hci_cmd_post_cb = NULL;
+static void *hci_cmd_post_cb_user_data = NULL;
+
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
 static enum {
     ADV_MODE_ANY,
@@ -848,8 +851,7 @@ ble_ll_write_rf_path_compensation(const uint8_t *cmdbuf, uint8_t len)
  */
 static int
 ble_ll_hci_le_cmd_proc(const uint8_t *cmdbuf, uint8_t len, uint16_t ocf,
-                       uint8_t *rspbuf, uint8_t *rsplen,
-                       ble_ll_hci_post_cmd_complete_cb *cb)
+                       uint8_t *rspbuf, uint8_t *rsplen)
 {
     int rc;
 
@@ -929,7 +931,7 @@ ble_ll_hci_le_cmd_proc(const uint8_t *cmdbuf, uint8_t len, uint16_t ocf,
         break;
     case BLE_HCI_OCF_LE_CREATE_CONN_CANCEL:
         if (len == 0) {
-            rc = ble_ll_conn_create_cancel(cb);
+            rc = ble_ll_conn_create_cancel();
         }
         break;
 #endif
@@ -1156,7 +1158,7 @@ ble_ll_hci_le_cmd_proc(const uint8_t *cmdbuf, uint8_t len, uint16_t ocf,
         break;
     case BLE_HCI_OCF_LE_PERIODIC_ADV_CREATE_SYNC_CANCEL:
         if (len == 0) {
-            rc = ble_ll_sync_cancel(cb);
+            rc = ble_ll_sync_cancel();
         }
         break;
     case BLE_HCI_OCF_LE_PERIODIC_ADV_TERM_SYNC:
@@ -1713,6 +1715,15 @@ ble_ll_hci_cmd_fake_dual_mode(uint16_t opcode,  uint8_t *cmdbuf, uint8_t len,
 }
 #endif
 
+
+void
+ble_ll_hci_post_cmd_cb_set(ble_ll_hci_post_cmd_complete_cb cb, void *user_data)
+{
+    BLE_LL_ASSERT(hci_cmd_post_cb == NULL);
+    hci_cmd_post_cb = cb;
+    hci_cmd_post_cb_user_data = user_data;
+}
+
 /**
  * Called to process an HCI command from the host.
  *
@@ -1727,7 +1738,6 @@ ble_ll_hci_cmd_proc(struct ble_npl_event *ev)
     struct ble_hci_cmd *cmd;
     uint16_t opcode;
     uint16_t ocf;
-    ble_ll_hci_post_cmd_complete_cb post_cb = NULL;
     struct ble_hci_ev *hci_ev;
     struct ble_hci_ev_command_status *cmd_status;
     struct ble_hci_ev_command_complete *cmd_complete;
@@ -1794,7 +1804,7 @@ ble_ll_hci_cmd_proc(struct ble_npl_event *ev)
         rc = ble_ll_hci_status_params_cmd_proc(cmd->data, cmd->length, ocf, rspbuf, &rsplen);
         break;
     case BLE_HCI_OGF_LE:
-        rc = ble_ll_hci_le_cmd_proc(cmd->data, cmd->length, ocf, rspbuf, &rsplen, &post_cb);
+        rc = ble_ll_hci_le_cmd_proc(cmd->data, cmd->length, ocf, rspbuf, &rsplen);
         break;
 #if MYNEWT_VAL(BLE_LL_HCI_VS)
     case BLE_HCI_OGF_VENDOR:
@@ -1852,8 +1862,11 @@ send_cc_cs:
     ble_ll_hci_event_send(hci_ev);
 
     /* Call post callback if set by command handler */
-    if (post_cb) {
-        post_cb();
+    if (hci_cmd_post_cb) {
+        hci_cmd_post_cb(hci_cmd_post_cb_user_data);
+
+        hci_cmd_post_cb = NULL;
+        hci_cmd_post_cb_user_data = NULL;
     }
 
     BLE_LL_DEBUG_GPIO(HCI_CMD, 0);

--- a/nimble/controller/src/ble_ll_sync.c
+++ b/nimble/controller/src/ble_ll_sync.c
@@ -1560,13 +1560,13 @@ ble_ll_sync_create(const uint8_t *cmdbuf, uint8_t len)
 }
 
 static void
-ble_ll_sync_cancel_complete_event(void)
+ble_ll_sync_cancel_complete_event(void *user_data)
 {
     ble_ll_sync_est_event_failed(BLE_ERR_OPERATION_CANCELLED);
 }
 
 int
-ble_ll_sync_cancel(ble_ll_hci_post_cmd_complete_cb *post_cmd_cb)
+ble_ll_sync_cancel(void)
 {
     struct ble_ll_sync_sm *sm;
     os_sr_t sr;
@@ -1597,7 +1597,7 @@ ble_ll_sync_cancel(ble_ll_hci_post_cmd_complete_cb *post_cmd_cb)
     OS_EXIT_CRITICAL(sr);
 
     /* g_ble_ll_sync_create_comp_ev will be cleared by this callback */
-    *post_cmd_cb = ble_ll_sync_cancel_complete_event;
+    ble_ll_hci_post_cmd_cb_set(ble_ll_sync_cancel_complete_event, NULL);
 
     return BLE_ERR_SUCCESS;
 }


### PR DESCRIPTION
Updating Min/Max CE Length can be done without triggering LL procedure. We can do that if current connection parameters fits parameters parameters provided in HCI command. Note that this is also valid for Connections Strict Scheduling.

Upstream commit: 631380aab0e02f8690bd2b3f87c6cc83e439d509