### PR TITLE
nimble/ll: Add few useful macros

### DIFF
--- a/nimble/controller/include/controller/ble_ll_utils.h
+++ b/nimble/controller/include/controller/ble_ll_utils.h
@@ -23,6 +23,11 @@
 #define INT16_LT(_a, _b) ((int16_t)((_a) - (_b)) < 0)
 #define INT16_LTE(_a, _b) ((int16_t)((_a) - (_b)) <= 0)
 
+#define MIN(_a, _b) ((_a) < (_b) ? (_a) : (_b))
+#define MAX(_a, _b) ((_a) > (_b) ? (_a) : (_b))
+#define CLAMP(_n, _min, _max) (MAX(_min, MIN(_n, _max)))
+#define IN_RANGE(_n, _min, _max) (((_n) >= (_min)) && ((_n) <= (_max)))
+
 uint32_t ble_ll_utils_calc_access_addr(void);
 uint8_t ble_ll_utils_remapped_channel(uint8_t remap_index, const uint8_t *chanmap);
 uint8_t ble_ll_utils_dci_csa2(uint16_t counter, uint16_t chan_id,


### PR DESCRIPTION
This backport following upstream commits:
6e9b61b1c8f6a715ae7fc4676eeecf2ac1fd45e4
511ad6a9e678532a35e9a4cc7af8742251fca685